### PR TITLE
compute-decorator: extism decorator function to invoke host-function

### DIFF
--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -1,5 +1,12 @@
+import extism
 import json
 import traceback
+
+# The idea is to keep the host functions wrapped under the extism interface
+# As of now, host_callback is the host function that we intend to expose.
+@extism.import_fn("fc", "host_callback")
+def host_callback(typ: str, payload: str) -> str:
+    pass
 
 
 def __invoke(index, shared, *args):

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -88,6 +88,23 @@ def import_fn(module, name):
     return inner
 
 
+def compute(func):
+    def wrapper(input: str):
+        # Call the host_callback
+        import json
+        payload = json.dumps({"name": func.__name__, "args": input})
+        args = ("compute", payload)
+        args = [_store(a) for a in args]
+        ret = str
+        # The host_callback function is imported at index 0,
+        # so we make that assumption and pass index 0 to invoke the required
+        # host function.
+        res = ffi.__invoke_host_func(0, *args)
+        return _load(ret, res)
+
+    return wrapper
+
+
 def plugin_fn(func):
     """Annotate a function that will be called by Extism"""
     global __exports


### PR DESCRIPTION
Define "compute" wrapper function which internally invokes host function called "host_callback". The inner closure function takes the function name to which compute is wrapper and its payload to build the input args for the host_callback function.

The host_callback function takes following arguments:
  * type: same as the decorator function name
  * payload: generated from the function name to which compute is decorator and its arguments. We assume that there is only one argument for now.

We make an assumption here that host_callback is the only host function defined as part of the script, that is why it is safe to assume the index to be "0" when invoking the host function using __invoke_host_func implementation.