### PR TITLE
skip number of arguments check

### DIFF
--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -1,3 +1,4 @@
+import json
 import traceback
 
 
@@ -14,7 +15,9 @@ def __invoke(index, shared, *args):
                 t = f.__annotations__.get(argnames[i], extism.memory.MemoryHandle)
                 a.append(extism._load(t, arg))
         else:
-            a = [extism._store(x) for x in args]
+            # For now, we only export the functions which takes single argument.
+            # The only argument that is passed on is assumed to be a string.
+            a = [json.loads(extism.input_str())]
 
         res = f(*a)
         if shared and res is not None:

--- a/bin/src/py.rs
+++ b/bin/src/py.rs
@@ -48,7 +48,13 @@ fn get_export<R: std::fmt::Debug>(
 ) -> Result<Export, Error> {
     let func = f.name.to_string();
 
-    let n_args = f.args.args.len();
+    // let n_args = f.args.args.len();
+    // The extism doesn't support exported function with arguments.
+    // But we have added logic in the invoke.py to fetch the input_str and
+    // pass it the caller function.
+    // This is again with the assumption that exported functions always take
+    // single argument and that has to be of str type.
+    let n_args = 0;
     let has_return = f.returns.is_some();
 
     if is_plugin_fn && n_args > 0 {


### PR DESCRIPTION
For the imported functions, skip the arguments check because the function will have arguments i.e a single argument which will be of type str.

The argument is passed by the __invoke function as per what it receives from the caller.