### PR TITLE
query and signal: Support to take arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Cargo.lock
 extism-py
 examples/*.wasm
 .envrc
+.idea
+


### PR DESCRIPTION
Add support to fetch the arguments from the query & signal request and pass it to the respective function. For now, support will be for keyword arguments only.