### PR TITLE
Support for arguments and return types

### DIFF
--- a/bin/src/invoke.py
+++ b/bin/src/invoke.py
@@ -30,11 +30,13 @@ def __invoke(index, shared, *args):
                 t = f.__annotations__.get(argnames[i], extism.memory.MemoryHandle)
                 a.append(extism._load(t, arg))
         else:
-            # For now, we only export the functions which takes single argument.
-            # The only argument that is passed on is assumed to be a string.
-            a = [json.loads(extism.input_str())]
+            # The arguments to the function always have to be keyword mapped.
+            # It is marshalled JSON.
+            a = json.loads(extism.input_str())
 
-        res = f(*a)
+        res = f(**a)
+
+        extism.output(res)
         if shared and res is not None:
             return extism._store(res)
         if res is not None and "return" in f.__annotations__:

--- a/lib/src/prelude.py
+++ b/lib/src/prelude.py
@@ -142,10 +142,10 @@ def _invoke_host_func(typ: str, payload: str):
 
 
 def compute(func):
-    def wrapper(input: str):
+    def wrapper(**kwargs):
         # Call the host_callback
         import json
-        payload = json.dumps({"name": func.__name__, "args": input})
+        payload = json.dumps({"name": func.__name__, "args": json.dumps(kwargs)})
         result = _invoke_host_func("compute", payload)
         return result["ret"]
 


### PR DESCRIPTION
We make an assumption here that arguments are always keywords mapped and the output is JSON marshalled.